### PR TITLE
Add output-validator turn usage helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,10 @@ const result = await toolSearch.execute(
 Validate the exact final JSON response against a JSON Schema configured by the application.
 
 ```typescript
-import { createOutputValidator } from 'agentool/output-validator';
+import {
+  checkOutputValidatorUsage,
+  createOutputValidator,
+} from 'agentool/output-validator';
 
 const outputValidator = createOutputValidator({
   schemaId: 'answer-v1',
@@ -423,6 +426,32 @@ const tools = {
 ```
 
 If the schema changes on the next turn, create a new validator and pass it under the same tool name. No new chat session is required as long as your app rebuilds the tool list for that model call.
+
+After a model turn, check whether the validator was called. If the turn ended
+normally without validation, send the corrective prompt in the next interaction:
+
+```typescript
+const result = await generateText({
+  model,
+  tools,
+  prompt: 'Return the answer as JSON.',
+});
+const usage = checkOutputValidatorUsage(result);
+
+if (result.finishReason === 'stop' && !usage.wasCalled) {
+  await generateText({
+    model,
+    tools,
+    prompt: usage.correctivePrompt,
+  });
+}
+```
+
+For a custom tool key, pass the same name to the helper:
+
+```typescript
+checkOutputValidatorUsage(result, { toolName: 'json_guard' });
+```
 
 Validation errors include `path`, `message`, `keyword`, Ajv metadata, and `instanceValue` when the failing JSON value can be resolved. `instanceValue` is compact JSON truncated to about 200 characters.
 
@@ -863,7 +892,7 @@ import {
   webFetch, createWebFetch,
   webSearch, createWebSearch,
   toolSearch, createToolSearch,
-  outputValidator, createOutputValidator,
+  outputValidator, createOutputValidator, checkOutputValidatorUsage,
   httpRequest, createHttpRequest,
   memory, createMemory,
   multiEdit, createMultiEdit,
@@ -900,7 +929,7 @@ import { taskUpdate } from 'agentool/task-update';
 import { taskList } from 'agentool/task-list';
 import { webSearch } from 'agentool/web-search';
 import { toolSearch } from 'agentool/tool-search';
-import { outputValidator } from 'agentool/output-validator';
+import { outputValidator, checkOutputValidatorUsage } from 'agentool/output-validator';
 import { lsp } from 'agentool/lsp';
 import { compactMessages } from 'agentool/context-compaction'; // helper function
 import { askUser } from 'agentool/ask-user';

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,14 +53,22 @@ export type { LspConfig } from './lsp/index.js';
 export { createHttpRequest, httpRequest, httpRequestPrompt } from './http-request/index.js';
 export type { HttpRequestConfig } from './http-request/index.js';
 
-export { createOutputValidator, outputValidator, outputValidatorPrompt } from './output-validator/index.js';
+export {
+  checkOutputValidatorUsage,
+  createOutputValidator,
+  outputValidator,
+  outputValidatorPrompt,
+} from './output-validator/index.js';
 export type {
   JsonSchema,
   JsonSchemaObject,
   JsonSchemaValue,
   OutputValidationError,
   OutputValidationResult,
+  OutputValidatorTurnLike,
   OutputValidatorConfig,
+  OutputValidatorUsageOptions,
+  OutputValidatorUsageResult,
 } from './output-validator/index.js';
 
 export { compactMessages } from './middleware/context-compaction/index.js';

--- a/src/output-validator/index.ts
+++ b/src/output-validator/index.ts
@@ -15,6 +15,12 @@ import { getPrompt } from './prompt.js';
 import { hasOneOfDiscriminator } from './schema.js';
 
 export { getPrompt as outputValidatorPrompt } from './prompt.js';
+export { checkOutputValidatorUsage } from './usage.js';
+export type {
+  OutputValidatorTurnLike,
+  OutputValidatorUsageOptions,
+  OutputValidatorUsageResult,
+} from './usage.js';
 
 export type JsonSchemaValue =
   | string

--- a/src/output-validator/usage.ts
+++ b/src/output-validator/usage.ts
@@ -1,0 +1,100 @@
+import { isRecord } from './json-pointer.js';
+
+const DEFAULT_OUTPUT_VALIDATOR_TOOL_NAME = 'output_validator';
+
+export interface OutputValidatorUsageOptions {
+  /**
+   * Tool name used in the AI SDK tools object.
+   * Defaults to output_validator.
+   */
+  toolName?: string;
+}
+
+export interface OutputValidatorTurnLike {
+  /** Tool calls from the last turn or step. */
+  toolCalls?: unknown;
+  /** Multi-step generation results, each with its own toolCalls array. */
+  steps?: unknown;
+  /** Other AI SDK result fields such as finishReason are ignored. */
+  [key: string]: unknown;
+}
+
+export type OutputValidatorUsageResult =
+  | {
+    /** Tool name checked by the helper. */
+    toolName: string;
+    /** True when a matching validator tool call exists in the turn. */
+    wasCalled: true;
+    correctivePrompt?: never;
+  }
+  | {
+    /** Tool name checked by the helper. */
+    toolName: string;
+    /** False when no matching validator tool call exists in the turn. */
+    wasCalled: false;
+    /** Follow-up instruction for the next LLM interaction. */
+    correctivePrompt: string;
+  };
+
+/**
+ * Inspect an AI SDK result-like object for an output-validator tool call.
+ *
+ * The check is structural: it looks for matching `toolName` values in
+ * top-level `toolCalls` and in each `steps[].toolCalls` array. Use this after
+ * a turn finishes with `finishReason: 'stop'` to decide whether to continue
+ * with the returned corrective prompt.
+ */
+export function checkOutputValidatorUsage(
+  turn: OutputValidatorTurnLike,
+  options: OutputValidatorUsageOptions = {},
+): OutputValidatorUsageResult {
+  const toolName = getOutputValidatorToolName(options);
+  const wasCalled =
+    hasToolCallNamed(turn.toolCalls, toolName) ||
+    hasStepToolCallNamed(turn.steps, toolName);
+
+  if (wasCalled) {
+    return { toolName, wasCalled };
+  }
+
+  return {
+    toolName,
+    wasCalled,
+    correctivePrompt: getOutputValidatorCorrectivePrompt(toolName),
+  };
+}
+
+function getOutputValidatorToolName(
+  options: OutputValidatorUsageOptions,
+): string {
+  const toolName = options.toolName?.trim();
+  return toolName && toolName.length > 0
+    ? toolName
+    : DEFAULT_OUTPUT_VALIDATOR_TOOL_NAME;
+}
+
+function hasStepToolCallNamed(steps: unknown, toolName: string): boolean {
+  return Array.isArray(steps) && steps.some((step) =>
+    isRecord(step) && hasToolCallNamed(step.toolCalls, toolName)
+  );
+}
+
+function hasToolCallNamed(toolCalls: unknown, toolName: string): boolean {
+  return Array.isArray(toolCalls) && toolCalls.some((toolCall) =>
+    getToolCallName(toolCall) === toolName
+  );
+}
+
+function getToolCallName(toolCall: unknown): string | undefined {
+  if (!isRecord(toolCall)) {
+    return undefined;
+  }
+
+  return typeof toolCall.toolName === 'string'
+    ? toolCall.toolName
+    : undefined;
+}
+
+function getOutputValidatorCorrectivePrompt(toolName: string): string {
+  return `The previous response ended without validating the final JSON. In the next interaction, call ${toolName}({"content":"<full JSON document as a string>"}) with the complete final JSON document in the content string parameter. Do not return another final answer until that validator call reports valid: true.`;
+}

--- a/tests/unit/output-validator.test.ts
+++ b/tests/unit/output-validator.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  checkOutputValidatorUsage,
   createOutputValidator,
   outputValidator,
   type JsonSchema,
@@ -13,6 +14,91 @@ function parseResult(raw: string): OutputValidationResult {
 }
 
 describe('output-validator tool', () => {
+  describe('turn usage helpers', () => {
+    it('reports a missing validator call and returns a corrective prompt', () => {
+      const result = checkOutputValidatorUsage({
+        finishReason: 'stop',
+        toolCalls: [],
+        steps: [],
+      });
+
+      expect(result).toMatchObject({
+        toolName: 'output_validator',
+        wasCalled: false,
+      });
+      expect(result.correctivePrompt).toContain(
+        'output_validator({"content":"<full JSON document as a string>"})',
+      );
+      expect(result.correctivePrompt).toContain('content string parameter');
+      expect(result.correctivePrompt).toContain(
+        'Do not return another final answer',
+      );
+    });
+
+    it('detects a top-level validator tool call', () => {
+      const result = checkOutputValidatorUsage({
+        finishReason: 'tool-calls',
+        toolCalls: [
+          { toolCallId: 'other-1', toolName: 'other_tool' },
+          { toolCallId: 'validator-1', toolName: 'output_validator' },
+        ],
+      });
+
+      expect(result).toEqual({
+        toolName: 'output_validator',
+        wasCalled: true,
+      });
+    });
+
+    it('detects a validator tool call inside multi-step results', () => {
+      const result = checkOutputValidatorUsage({
+        finishReason: 'stop',
+        toolCalls: [],
+        steps: [
+          { toolCalls: [{ toolCallId: 'search-1', toolName: 'web_search' }] },
+          {
+            toolCalls: [
+              { toolCallId: 'validator-1', toolName: 'output_validator' },
+            ],
+          },
+        ],
+      });
+
+      expect(result).toEqual({
+        toolName: 'output_validator',
+        wasCalled: true,
+      });
+    });
+
+    it('uses a custom validator tool name when provided', () => {
+      const turn = {
+        toolCalls: [{ toolCallId: 'validator-1', toolName: 'json_guard' }],
+      };
+
+      expect(checkOutputValidatorUsage(turn)).toMatchObject({
+        toolName: 'output_validator',
+        wasCalled: false,
+      });
+      expect(
+        checkOutputValidatorUsage(turn, { toolName: 'json_guard' }),
+      ).toEqual({
+        toolName: 'json_guard',
+        wasCalled: true,
+      });
+    });
+
+    it('uses the custom validator tool name in corrective prompts', () => {
+      const result = checkOutputValidatorUsage(
+        { finishReason: 'stop', toolCalls: [] },
+        { toolName: 'json_guard' },
+      );
+
+      expect(result.correctivePrompt).toContain(
+        'json_guard({"content":"<full JSON document as a string>"})',
+      );
+    });
+  });
+
   describe('default export', () => {
     it('exists and has an execute function', () => {
       expect(outputValidator).toBeDefined();


### PR DESCRIPTION
## Summary
- add checkOutputValidatorUsage for top-level and step-level validator tool-call detection
- return a corrective follow-up prompt when validation was missed
- document the follow-up flow and add output-validator helper tests

Closes #4

## Verification
- npm run test -- tests/unit/output-validator.test.ts
- npm run typecheck
- npm run lint
- npm run build
- git diff --check